### PR TITLE
Align vertically, add margin to rows in tables

### DIFF
--- a/frontend/src/styles/_global.scss
+++ b/frontend/src/styles/_global.scss
@@ -42,6 +42,11 @@ header {
   top: $pt-navbar-height;
 }
 
+.row {
+  align-items: center;
+  margin-bottom: 5px;
+}
+
 .is-paddingless {
   padding-top: 0px !important;
 }


### PR DESCRIPTION
Make rows prettier with vertical alignment and a small bottom margin.

Granted, this is completely unnecessary given the migration to [cadet](https://github.com/source-academy/cadet), but it did help me get to know the project _a little_. Also helps me get a feel of the workflow.

![2018-02-03_scrot](https://user-images.githubusercontent.com/22320312/35765588-2032f87e-0902-11e8-9a27-7b7302091234.png)
_(left: original, right: this change)_

---

Without vertical align, text would be flush to the top such that it would seem to be off center with any buttons (if any) in the same row.

Without margin-bottom, buttons would have touching borders.

Added these changes to _global.scss, since rows in tables may occur throughout the site. _global.scss seemed to be the most semantically appropriate location.